### PR TITLE
Fix blurry sprites on chrome when upscaled

### DIFF
--- a/heads_contest/style.css
+++ b/heads_contest/style.css
@@ -5,6 +5,7 @@ body {
 
 img {
 	width: 576px;
+	image-rendering: pixelated;
 	image-rendering: crisp-edges;
 }
 


### PR DESCRIPTION
Fix blurry sprites on chrome when upscaled

NOTE: this might break in future updates when both pixelated and crisp-edges are supported by Chrome and Firefox simultaneously.